### PR TITLE
Fix field description in Milvus collection creation script

### DIFF
--- a/question_answer/create_milvus_collection.py
+++ b/question_answer/create_milvus_collection.py
@@ -8,8 +8,8 @@ def create_milvus_collection(collection_name, dim):
         utility.drop_collection(collection_name)
     
     fields = [
-    FieldSchema(name='id', dtype=DataType.VARCHAR, descrition='ids', max_length=500, is_primary=True, auto_id=False),
-    FieldSchema(name='embedding', dtype=DataType.FLOAT_VECTOR, descrition='embedding vectors', dim=dim)
+    FieldSchema(name='id', dtype=DataType.VARCHAR, description='ids', max_length=500, is_primary=True, auto_id=False),
+    FieldSchema(name='embedding', dtype=DataType.FLOAT_VECTOR, description='embedding vectors', dim=dim)
     ]
     schema = CollectionSchema(fields=fields, description='Question Answering System')
     collection = Collection(name=collection_name, schema=schema)
@@ -25,3 +25,4 @@ def create_milvus_collection(collection_name, dim):
 
 collection = create_milvus_collection(mvar.get_collection_name(), mvar.get_collection_dim())
 print('Total number of inserted data is {}.'.format(collection.num_entities))
+


### PR DESCRIPTION
## Summary
- correct typos in `FieldSchema` kwargs

## Testing
- `python3 -m py_compile question_answer/create_milvus_collection.py`
- `python3 question_answer/create_milvus_collection.py` *(fails: ModuleNotFoundError: No module named 'pymilvus')*

------
https://chatgpt.com/codex/tasks/task_e_684163223b988320af3a7567ad7283bd