### PR TITLE
Add unit tests for Milvus defaults

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+import unittest
+import os
+
+
+def load_tests(loader, tests, pattern):
+    start_dir = os.path.dirname(__file__)
+    return loader.discover(start_dir)

--- a/tests/test_milvus_v.py
+++ b/tests/test_milvus_v.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import unittest
+import importlib
+
+class TestMilvusVDefaults(unittest.TestCase):
+    def setUp(self):
+        # Save and clear environment variables
+        self.saved = {k: os.environ.pop(k, None) for k in ['MILVUS_IP', 'MILVUS_PORT', 'MILVUS_DATASET_PATH']}
+        if 'question_answer.common.milvus_v' in sys.modules:
+            del sys.modules['question_answer.common.milvus_v']
+        self.milvus_v = importlib.import_module('question_answer.common.milvus_v')
+
+    def tearDown(self):
+        # Restore environment variables
+        for k, v in self.saved.items():
+            if v is not None:
+                os.environ[k] = v
+        if 'question_answer.common.milvus_v' in sys.modules:
+            del sys.modules['question_answer.common.milvus_v']
+        importlib.import_module('question_answer.common.milvus_v')
+
+    def test_get_ip_default(self):
+        self.assertEqual(self.milvus_v.get_ip(), '127.0.0.1')
+
+    def test_get_port_default(self):
+        self.assertEqual(self.milvus_v.get_port(), '19530')
+
+    def test_get_q_a_path_default(self):
+        self.assertEqual(self.milvus_v.get_q_a_path(), './dataset/question_answer.csv')
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- create test suite for question_answer.common.milvus_v
- ensure python -m unittest discovers tests automatically

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_684163222514832098c75bab337880b5